### PR TITLE
Add QEMU and Buildx setup for multi-platform Docker builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -59,5 +65,6 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/assignments/tests.py
+++ b/assignments/tests.py
@@ -457,7 +457,7 @@ class AssignmentAPITests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
     
     def test_list_assignments(self):
-        """GET /api/assignments/ debe listar asignaciones"""
+        """GET /api/assignments/ debe listar asignaciones como array plano"""
         # Crear algunas asignaciones
         TicketAssignment.objects.create(
             ticket_id='API-LIST-1',
@@ -468,6 +468,7 @@ class AssignmentAPITests(TestCase):
         response = self.client.get('/api/assignments/')
         
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsInstance(response.data, list)
         self.assertGreaterEqual(len(response.data), 1)
     
     def test_reassign_ticket_via_api(self):
@@ -675,4 +676,3 @@ class CeleryTaskTests(TestCase):
         self.assertTrue(
             TicketAssignment.objects.filter(ticket_id='APPLY-1').exists()
         )
-

--- a/assignments/tests/test_assignments.py
+++ b/assignments/tests/test_assignments.py
@@ -498,8 +498,7 @@ class AssignmentAPITests(TestCase):
         self.assertIn('ticket_id', response.data)
 
     def test_list_assignments(self):
-        """GET /api/assignments/ debe listar asignaciones"""
-        # Crear más de una página de resultados
+        """GET /api/assignments/ debe retornar un array plano sin paginación."""
         for index in range(25):
             TicketAssignment.objects.create(
                 ticket_id=f'API-LIST-{index}',
@@ -510,12 +509,8 @@ class AssignmentAPITests(TestCase):
         response = self.client.get('/api/assignments/')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('count', response.data)
-        self.assertIn('next', response.data)
-        self.assertIn('previous', response.data)
-        self.assertIn('results', response.data)
-        self.assertEqual(response.data['count'], 25)
-        self.assertEqual(len(response.data['results']), 20)
+        self.assertIsInstance(response.data, list)
+        self.assertEqual(len(response.data), 25)
 
     @patch('assignments.infrastructure.messaging.event_publisher.RabbitMQEventPublisher.publish')
     def test_reassign_ticket_via_api(self, mock_publish):

--- a/assignments/views.py
+++ b/assignments/views.py
@@ -22,6 +22,7 @@ class TicketAssignmentViewSet(viewsets.ModelViewSet):
     """
     queryset = TicketAssignment.objects.all().order_by('-assigned_at')
     serializer_class = TicketAssignmentSerializer
+    pagination_class = None
     
     def __init__(self, *args, container=None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -119,4 +120,3 @@ class TicketAssignmentViewSet(viewsets.ModelViewSet):
                 {'error': str(e)},
                 status=status.HTTP_400_BAD_REQUEST
             )
-

--- a/messaging/consumer.py
+++ b/messaging/consumer.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 
 
 RABBIT_HOST = os.environ.get('RABBITMQ_HOST')
+RABBIT_USER = os.environ.get('RABBITMQ_USER', 'guest')
+RABBIT_PASS = os.environ.get('RABBITMQ_PASSWORD', 'guest')
 EXCHANGE_NAME = os.environ.get('RABBITMQ_EXCHANGE_NAME')
 QUEUE_NAME = os.environ.get('RABBITMQ_QUEUE_ASSIGNMENT')
 
@@ -158,8 +160,9 @@ def start_consuming() -> None:
     while True:
         try:
             logger.info("Connecting to RabbitMQ at %s...", RABBIT_HOST)
+            credentials = pika.PlainCredentials(RABBIT_USER, RABBIT_PASS)
             connection = pika.BlockingConnection(
-                pika.ConnectionParameters(host=RABBIT_HOST)
+                pika.ConnectionParameters(host=RABBIT_HOST, credentials=credentials)
             )
             channel = connection.channel()
 


### PR DESCRIPTION
This pull request introduces several improvements across the codebase, focusing on enhancing the Docker publishing workflow, updating the assignment API to return a flat array without pagination, and improving RabbitMQ consumer configuration. The most significant change is the removal of pagination from the assignments API, ensuring that responses are returned as a plain list, which is reflected in both the view logic and the associated tests. Additionally, the Docker workflow now supports multi-architecture builds, and the RabbitMQ consumer is updated to support configurable authentication.

**Assignments API: Flat Array Response and No Pagination**
- Removed pagination from the `TicketAssignmentViewSet` by setting `pagination_class = None`, ensuring that the assignments API returns a flat array instead of a paginated result.
- Updated tests in both `assignments/tests.py` and `assignments/tests/test_assignments.py` to assert that the API response is a list and no longer contains pagination fields. [[1]](diffhunk://#diff-68a7f30ed0c0f6e51991033246a2dd9927e81e85251f9db6e426bfcb9c65da23L460-R460) [[2]](diffhunk://#diff-68a7f30ed0c0f6e51991033246a2dd9927e81e85251f9db6e426bfcb9c65da23R471) [[3]](diffhunk://#diff-cd36afdaad4920755aa25b80214d4aed125dbb1abf8a0fb331b84ffed73ea8b0L501-R501) [[4]](diffhunk://#diff-cd36afdaad4920755aa25b80214d4aed125dbb1abf8a0fb331b84ffed73ea8b0L513-R513)

**Docker Workflow: Multi-Architecture Support**
- Added QEMU and Docker Buildx setup steps to the GitHub Actions workflow in `.github/workflows/publish.yml` to enable building images for multiple architectures.
- Configured the Docker build step to build and push images for both `linux/amd64` and `linux/arm64` platforms.

**RabbitMQ Consumer: Configurable Authentication**
- Added support for setting RabbitMQ username and password via environment variables, defaulting to `'guest'` if not provided, in `messaging/consumer.py`.
- Updated the consumer to use these credentials when connecting to RabbitMQ.